### PR TITLE
fix: language configuration

### DIFF
--- a/LSP-svelte.sublime-settings
+++ b/LSP-svelte.sublime-settings
@@ -1,16 +1,5 @@
 {
 	"command": ["${node_bin}", "${server_path}", "--stdio"],
-	// ST3
-	"languages": [
-		{
-			"scopes": ["text.html.svelte"],
-			"syntaxes": [
-				"Packages/Svelte/Svelte.sublime-syntax"
-			],
-		}
-	],
-	// ST4
-	"selector": "text.html.svelte",
 	"disabled_capabilities": {},
 	"initializationOptions": {
 		"configuration": {
@@ -129,5 +118,15 @@
 			}
 		}
 	},
-	"settings": {}
+	"settings": {},
+	// ST4
+	"selector": "text.html.svelte",
+	// ST3
+	"languages": [
+		{
+			"languageId": "svelte",
+			"scopes": ["text.html.svelte"],
+			"syntaxes": ["Packages/Svelte/Svelte.sublime-syntax"],
+		}
+	],
 }


### PR DESCRIPTION
I'm going through all packages and updating the language configuration (fix if needed). In this case ST4 configuration was fine but I think the ST3 one needs a `languageId`. The server might in theory malfunction without wrong language ID.