### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/LSP-svelte.sublime-settings
+++ b/LSP-svelte.sublime-settings
@@ -25,7 +25,7 @@
 		"typescript.inlayHints.variableTypes.enabled": false,
 		"typescript.inlayHints.variableTypes.suppressWhenTypeMatchesName.enabled": true,
 	},
-	"initializationOptions": {
+	"initialization_options": {
 		"configuration": {
 			"svelte": {
 				"plugin": {


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
