### PR TITLE
fix: don't manually register watcher

### DIFF
--- a/LSP-svelte.sublime-settings
+++ b/LSP-svelte.sublime-settings
@@ -1,9 +1,5 @@
 {
 	"command": ["${node_bin}", "${server_path}", "--stdio"],
-	"file_watcher": {
-		"patterns": ["{**/*.js,**/*.ts}"],
-		"events": ["create", "change", "delete"]
-	},
 	"settings": {
  		// javascript inlay hint
 		"javascript.inlayHints.enumMemberValues.enabled": false,


### PR DESCRIPTION
This server now registers watching capability dynamically:

```
{
  "registrations": [
    {
      "id": "ef240f2f-1611-4788-b97b-f8723ed17910",
      "method": "workspace/didChangeWatchedFiles",
      "registerOptions": {
        "watchers": [
          {
            "globPattern": "**/*.{ts,js,mts,mjs,cjs,cts,json,svelte}"
          }
        ]
      }
    }
  ]
}
```